### PR TITLE
Fix address links to broken truncated address

### DIFF
--- a/app/components/shared/AddressBubble.tsx
+++ b/app/components/shared/AddressBubble.tsx
@@ -34,7 +34,7 @@ export default function AddressBubble(
   const accountType = props.addressProfile.account?.type;
   const profileLink =
     getProfileLink(name, accountType) ??
-    `${getChainExplorerByChainId(props.chainId)}/address/${address}`;
+    `${getChainExplorerByChainId(props.chainId)}/address/${props.addressProfile.accountAddress}`;
 
   return (
     <a


### PR DESCRIPTION
currently, clicking on an address leads you to a block explorer for an address like this: 0x123..abc instead of the full address