### PR TITLE
Support standard ens avatar urls

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,10 @@ module.exports = {
         protocol: 'https',
         hostname: 'ipfs.io',
       },
+      {
+        protocol: 'https',
+        hostname: 'euc.li',
+      },
     ],
   },
 };


### PR DESCRIPTION
Before and after photos - I made my ENS avatar with the standard ENS site and it uses euc.li urls for the images

![Screenshot 2024-06-29 at 3 41 54 PM](https://github.com/daimo-eth/ethreceipts/assets/89474773/fe97e8e5-2e0b-4b84-aa49-b914c7005002)
![Screenshot 2024-06-29 at 3 41 32 PM](https://github.com/daimo-eth/ethreceipts/assets/89474773/4f218d1e-6ac9-46e6-af5f-7b8abe9a8d15)
