### PR TITLE
fix bug

### DIFF
--- a/app/components/shared/AddressBubble.tsx
+++ b/app/components/shared/AddressBubble.tsx
@@ -25,7 +25,8 @@ function AddressField(props: { name: string; address: string; accountType: Accou
 export default function AddressBubble(
   props: Readonly<{ addressProfile: AddressProfile; chainId: number }>,
 ) {
-  const address = truncateAddress(props.addressProfile.accountAddress);
+  const address = props.addressProfile.accountAddress;
+  const truncatedAddress = truncateAddress(address);
   const pfp = props.addressProfile.account?.avatar ?? null;
   const name = props.addressProfile.account?.name || '';
   const nameInitial = name ? name[0].toUpperCase() : '0x';
@@ -56,7 +57,7 @@ export default function AddressBubble(
         )}
       </div>
       <div className='flex flex-row gap-x-1 items-center justify-start'>
-        <AddressField name={name} address={address} accountType={accountType} />
+        <AddressField name={name} address={truncatedAddress} accountType={accountType} />
       </div>
     </a>
   );


### PR DESCRIPTION
Clicking on a bare address account linked to the truncated address on basescan instead of the full address.

e.g. clicking on the recipient of https://ethreceipts.org/l/8453/16847808/158 linked to https://basescan.org/address/0x96c30e...19dd instead of https://basescan.org/address/0x96c30e33F830DDF0256269069212eb0873de19dd